### PR TITLE
RingBufferOut: set in_prod = in_cons

### DIFF
--- a/include/xen/be/RingBufferBase.hpp
+++ b/include/xen/be/RingBufferBase.hpp
@@ -272,7 +272,7 @@ public:
 				static_cast<uint8_t*>(mBuffer.get()) + offset)),
 		mNumEvents(size/sizeof(Event))
 	{
-		mPage->in_prod = 0;
+		mPage->in_prod = mPage->in_cons;
 
 		xen_wmb();
 	}


### PR DESCRIPTION
This is WA for xen input frontend.
When BE restarted FE doesn't clear in_cons.

Signed-off-by: Oleksandr Grytsov <al1img@gmail.com>