### PR TITLE
Pr rework frontend handling

### DIFF
--- a/include/xen/be/BackendBase.hpp
+++ b/include/xen/be/BackendBase.hpp
@@ -146,14 +146,15 @@ private:
 
 	domid_t mDomId;
 	std::string mDeviceName;
+	std::string mFrontendsPath;
 	XenStore mXenStore;
 	std::list<FrontendHandlerPtr> mFrontendHandlers;
-	std::list<domid_t> mFrontendDomIds;
 
 	Log mLog;
 
 	void frontendListChanged(const std::string& path);
-	void deviceListChanged(const std::string& path, domid_t domId);
+	void frontendPathChanged(const std::string& path, domid_t domId,
+							 uint16_t devId);
 	FrontendHandlerPtr getFrontendHandler(domid_t domId, uint16_t devId);
 };
 

--- a/include/xen/be/FrontendHandlerBase.hpp
+++ b/include/xen/be/FrontendHandlerBase.hpp
@@ -273,9 +273,9 @@ private:
 
 	std::vector<RingBufferPtr> mRingBuffers;
 
-	XenBackend::AsyncContext mAsyncContext;
-
 	std::mutex mMutex;
+
+	XenBackend::AsyncContext mAsyncContext;
 
 	Log mLog;
 

--- a/include/xen/be/Utils.hpp
+++ b/include/xen/be/Utils.hpp
@@ -135,6 +135,11 @@ public:
 	~AsyncContext();
 
 	/**
+	 * Stops async thread
+	 */
+	void stop();
+
+	/**
 	 * Adds a function to be called asynchronously
 	 * @param f
 	 */

--- a/src/BackendBase.cpp
+++ b/src/BackendBase.cpp
@@ -83,6 +83,10 @@ BackendBase::BackendBase(const string& name, const string& deviceName,
 	mXenStore(),
 	mLog(name.empty() ? "Backend" : name)
 {
+
+	mFrontendsPath = mXenStore.getDomainPath(mDomId) + "/backend/" +
+					 mDeviceName;
+
 	LOG(mLog, DEBUG) << "Create backend, device: " << deviceName << ", "
 					 << "dom Id: " << mDomId;
 }
@@ -109,10 +113,7 @@ void BackendBase::start()
 {
 	mXenStore.start();
 
-	string frontendListPath = mXenStore.getDomainPath(mDomId) + "/backend/" +
-							  mDeviceName;
-
-	mXenStore.setWatch(frontendListPath,
+	mXenStore.setWatch(mFrontendsPath,
 					   bind(&BackendBase::frontendListChanged, this, _1));
 }
 
@@ -129,11 +130,20 @@ void BackendBase::stop()
 
 void BackendBase::addFrontendHandler(FrontendHandlerPtr frontendHandler)
 {
-	if (getFrontendHandler(frontendHandler->getDomId(),
-						   frontendHandler->getDevId()))
+	auto domId = frontendHandler->getDomId();
+	auto devId = frontendHandler->getDevId();
+
+	if (getFrontendHandler(domId, devId))
 	{
 		throw BackendException("Frontend already exists");
 	}
+
+	auto frontendPath = mFrontendsPath + "/" + to_string(domId) + "/" +
+						to_string(devId);
+
+	mXenStore.setWatch(frontendPath,
+					   bind(&BackendBase::frontendPathChanged, this,
+							_1, domId, devId));
 
 	frontendHandler->start();
 
@@ -146,91 +156,59 @@ void BackendBase::addFrontendHandler(FrontendHandlerPtr frontendHandler)
 
 void BackendBase::frontendListChanged(const string& path)
 {
-	LOG(mLog, DEBUG) << "Frontend list changed";
-
-	// create list of existing doms
-	list<domid_t> removeDomIds = mFrontendDomIds;
-
 	for (auto frontend : mXenStore.readDirectory(path))
 	{
 		domid_t domId = stoi(frontend);
 
-		auto it = find_if(mFrontendDomIds.begin(), mFrontendDomIds.end(),
-						  [domId](domid_t val) { return val == domId; });
+		auto tmpPath = path + "/" + frontend;
 
-		if (it == mFrontendDomIds.end())
+		for (auto device : mXenStore.readDirectory(tmpPath))
 		{
-			// add new dom
-			mFrontendDomIds.push_back(domId);
+			uint16_t devId = stoi(device);
 
-			mXenStore.setWatch(path + "/" + to_string(domId),
-							   bind(&BackendBase::deviceListChanged, this,
-									_1, domId));
+			tmpPath += "/" + device;
+
+			if (mXenStore.checkIfExist(tmpPath))
+			{
+				try
+				{
+					if (!getFrontendHandler(domId, devId))
+					{
+						LOG(mLog, DEBUG) << "New frontend found, domid: "
+										 << domId << ", devid: " << devId;
+
+						onNewFrontend(domId, devId);
+					}
+				}
+				catch(const exception& e)
+				{
+					LOG(mLog, ERROR) << e.what();
+				}
+			}
 		}
-		else
-		{
-			// remove existing from removing list
-			removeDomIds.remove(domId);
-		}
-	}
-
-	// remove not existing doms
-	for(auto domId : removeDomIds)
-	{
-		mFrontendDomIds.remove(domId);
-
-		mXenStore.clearWatch(path + "/" + to_string(domId));
 	}
 }
 
-void BackendBase::deviceListChanged(const string& path, domid_t domId)
+void BackendBase::frontendPathChanged(const string& path, domid_t domId,
+									  uint16_t devId)
 {
-	LOG(mLog, DEBUG) << "Device list changed";
+	LOG(mLog, DEBUG) << "Frontend path changed: " << path;
 
-	list<FrontendHandlerPtr> removeFrontends;
-
-	// create list of existing frontend
-	for (auto frontend : mFrontendHandlers)
+	if (!mXenStore.checkIfExist(path))
 	{
-		if (frontend->getDomId() == domId)
+		mXenStore.clearWatch(path);
+
+		auto frontendHandler = getFrontendHandler(domId, devId);
+
+		if (frontendHandler)
 		{
-			removeFrontends.push_back(frontend);
+			LOG(mLog, DEBUG) << "Delete frontend, domid: "
+							 << domId << ", devid: " << devId;
+
+			frontendHandler->stop();
+
+			mFrontendHandlers.remove(frontendHandler);
 		}
-	}
-
-	for (auto device : mXenStore.readDirectory(path))
-	{
-		uint16_t devId = stoi(device);
-
-		auto frontend = getFrontendHandler(domId, devId);
-
-		if (!frontend)
-		{
-			LOG(mLog, INFO) << "Create new frontend: "
-							<< Utils::logDomId(domId, devId);
-
-			try
-			{
-				onNewFrontend(domId, devId);
-			}
-			catch(const exception& e)
-			{
-				LOG(mLog, ERROR) << e.what();
-			}
-		}
-		else
-		{
-			// remove existing frontend from removing list
-			removeFrontends.remove(frontend);
-		}
-	}
-
-	// remove not existing frontends
-	for(auto frontend : removeFrontends)
-	{
-		frontend->stop();
-
-		mFrontendHandlers.remove(frontend);
 	}
 }
 

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -172,6 +172,11 @@ AsyncContext::AsyncContext() :
 
 AsyncContext::~AsyncContext()
 {
+	stop();
+}
+
+void AsyncContext::stop()
+{
 	{
 		unique_lock<mutex> lock(mMutex);
 

--- a/src/XenStore.cpp
+++ b/src/XenStore.cpp
@@ -227,6 +227,8 @@ void XenStore::clearWatches()
 {
 	lock_guard<mutex> lock(mMutex);
 
+	LOG(mLog, DEBUG) << "Clear watches";
+
 	for (auto watch : mWatches)
 	{
 		xs_unwatch(mXsHandle, watch.first.c_str(), "");

--- a/test/mocks/XenStoreMock.cpp
+++ b/test/mocks/XenStoreMock.cpp
@@ -297,6 +297,14 @@ const char* XenStoreMock::readValue(const std::string& path)
 		return it->second.c_str();
 	}
 
+	for(auto entry : mEntries)
+	{
+		if (entry.first.compare(0, path.length(), path) == 0)
+		{
+			return "";
+		}
+	}
+
 	return nullptr;
 }
 

--- a/test/testRingBuffer.cpp
+++ b/test/testRingBuffer.cpp
@@ -316,6 +316,7 @@ TEST_CASE("RingBufferOut", "[ringbuffer]")
 			XENTEST_IN_RING_OFFS);
 
 	eventPage->in_cons = 0;
+	eventPage->in_prod = 0;
 
 	// prepare commands
 	xentest_event1 evt1 {32, 32};
@@ -348,5 +349,7 @@ TEST_CASE("RingBufferOut", "[ringbuffer]")
 				REQUIRE_FALSE(gError);
 			}
 		}
+
+		ringBuffer.stop();
 	}
 }


### PR DESCRIPTION
Change mechanism to create/delete frontend handler.
BackendBase watches /local/domain/0/backend/{device}.
If new frontend device entry appears it creates corresponding frontend handler and add this path
to watch. When frontend device entry is removed BackendBase deletes the frontend handler.