### PR TITLE
Log: add setting log stream buffer

### DIFF
--- a/include/xen/be/Log.hpp
+++ b/include/xen/be/Log.hpp
@@ -200,6 +200,15 @@ public:
 	 */
 	static std::string getLogMask() { return sLogMask; }
 
+	/**
+	 * Sets file to write log
+	 * @param[in] fileName file name
+	 */
+	static void setStreamBuffer(std::streambuf* streamBuffer)
+	{
+		mOutput.rdbuf(streamBuffer);
+	}
+
 private:
 
 	friend class LogLine;
@@ -208,6 +217,8 @@ private:
 	static bool sShowFileAndLine;
 	static std::string sLogMask;
 	static std::vector<std::pair<std::string, LogLevel>> sLogMaskItems;
+
+	static std::ostream mOutput;
 
 	std::string mName;
 	LogLevel mLevel;

--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -56,6 +56,8 @@ bool Log::sShowFileAndLine(false);
 string Log::sLogMask;
 vector<pair<string, LogLevel>> Log::sLogMaskItems;
 
+std::ostream Log::mOutput(cout.rdbuf());
+
 /// @cond HIDDEN_SYMBOLS
 
 size_t LogLine::sAlignmentLength = 0;
@@ -217,8 +219,7 @@ LogLine::~LogLine()
 
 		lock_guard<mutex> lock(mMutex);
 
-		cout << mStream.str();
-		cout.flush();
+		Log::mOutput << mStream.str();
 	}
 }
 


### PR DESCRIPTION
In order to redirect log to a file new
static method setStreamBuffer added to Log.
By default the stream buffer initialized
with cout.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>