### PR TITLE
Log: use comma as log mask separator

### DIFF
--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -79,7 +79,7 @@ bool Log::setLogMask(const string& mask)
 
 	vector<string> items;
 
-	splitMask(items, ';');
+	splitMask(items, ',');
 
 	sLogMaskItems.clear();
 


### PR DESCRIPTION
Semicolon is command separator in the shell.
Changed it to comma.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>