### PR TITLE
Move all mock related code to standalone mock lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ message(STATUS)
 # Compiler flags
 ################################################################################
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11 -Wall")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=gnu++11 -Wall")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 
 ################################################################################

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,10 @@ set(SOURCES
 
 add_library(xenbe SHARED ${SOURCES})
 
+if(WITH_TEST)
+	add_library(xenbemock SHARED ${SOURCES})
+endif()
+
 ################################################################################
 # Libraries
 ################################################################################
@@ -37,5 +41,12 @@ target_link_libraries(xenbe
 	xenctrl
 	pthread
 )
+
+if(WITH_TEST)
+	target_link_libraries(xenbemock
+		xenmock
+		pthread
+	)
+endif()
 
 install(TARGETS xenbe LIBRARY DESTINATION lib)

--- a/src/FrontendHandlerBase.cpp
+++ b/src/FrontendHandlerBase.cpp
@@ -87,15 +87,15 @@ void FrontendHandlerBase::start()
 {
 	lock_guard<mutex> lock(mMutex);
 
-	mXenStore.start();
-
-	setBackendState(XenbusStateInitialising);
-
 	mXenStore.setWatch(mFeStatePath,
 					   bind(&FrontendHandlerBase::frontendStateChanged, this));
 
 	mXenStore.setWatch(mBeStatePath,
 					   bind(&FrontendHandlerBase::backendStateChanged, this));
+
+	setBackendState(XenbusStateInitialising);
+
+	mXenStore.start();
 }
 
 void FrontendHandlerBase::stop()
@@ -238,19 +238,13 @@ void FrontendHandlerBase::initXenStorePathes()
 {
 	stringstream ss;
 
-	ss << mXenStore.getDomainPath(mFeDomId) << "/device/"
-	   << mDevName << "/" << mDevId;
-
-	mXsFrontendPath = ss.str();
-
-	ss.str("");
-	ss.clear();
-
 	ss << mXenStore.getDomainPath(mBeDomId) << "/backend/"
 	   << mDevName << "/"
 	   << mFeDomId << "/" << mDevId;
 
 	mXsBackendPath = ss.str();
+
+	mXsFrontendPath = mXenStore.readString(mXsBackendPath + "/frontend");
 
 	mFeStatePath = mXsFrontendPath + "/state";
 	mBeStatePath = mXsBackendPath + "/state";

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -222,7 +222,15 @@ void AsyncContext::run()
 
 		while(!mAsyncCalls.empty())
 		{
-			mAsyncCalls.front()();
+
+			auto asyncCall = mAsyncCalls.front();
+
+			lock.unlock();
+
+			asyncCall();
+
+			lock.lock();
+
 			mAsyncCalls.pop_front();
 		}
 	}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,12 +10,15 @@ include_directories( . )
 # Sources
 ################################################################################
 
-set(SOURCES
+set(MOCK_SOURCES
 	mocks/Pipe.cpp
 	mocks/XenCtrlMock.cpp
 	mocks/XenEvtchnMock.cpp
 	mocks/XenGnttabMock.cpp
 	mocks/XenStoreMock.cpp
+)
+
+set(TEST_SOURCES
 	testBackend.cpp
 	testFrontendHandler.cpp
 	testRingBuffer.cpp
@@ -29,8 +32,11 @@ set(SOURCES
 # Targets
 ################################################################################
 
-add_executable(unitTests ${SOURCES})
+add_library(xenmock STATIC ${MOCK_SOURCES})
 
+add_executable(unitTests ${TEST_SOURCES})
+
+target_link_libraries(unitTests xenmock)
 
 ################################################################################
 # Libraries

--- a/test/mocks/XenCtrlMock.hpp
+++ b/test/mocks/XenCtrlMock.hpp
@@ -22,6 +22,7 @@
 #define TEST_MOCKS_XENCTRLMOCK_HPP_
 
 #include <list>
+#include <mutex>
 
 extern "C" {
 #include <xenctrl.h>
@@ -31,22 +32,28 @@ class XenCtrlMock
 {
 public:
 
-	XenCtrlMock();
+	static void setErrorMode(bool errorMode)
+	{
+		std::lock_guard<std::mutex> lock(sMutex);
 
-	static XenCtrlMock* getLastInstance() { return sLastInstance; }
-	static void setErrorMode(bool errorMode) { mErrorMode = errorMode; }
-	static bool getErrorMode() { return mErrorMode; }
+		sErrorMode = errorMode;
+	}
+	static bool getErrorMode()
+	{
+		std::lock_guard<std::mutex> lock(sMutex);
 
-	void addDomInfo(const xc_domaininfo_t& info);
-	int getDomInfos(domid_t firstDom, unsigned int maxDoms,
-					xc_domaininfo_t* info);
+		return sErrorMode;
+	}
+
+	static void addDomInfo(const xc_domaininfo_t& info);
+	static int getDomInfos(domid_t firstDom, unsigned int maxDoms,
+						   xc_domaininfo_t* info);
 
 private:
 
-	static XenCtrlMock* sLastInstance;
-	static bool mErrorMode;
-
-	std::list<xc_domaininfo_t> mDomInfos;
+	static std::mutex sMutex;
+	static bool sErrorMode;
+	static std::list<xc_domaininfo_t> sDomInfos;
 };
 
 #endif /* TEST_MOCKS_XENCTRLMOCK_HPP_ */

--- a/test/mocks/XenEvtchnMock.hpp
+++ b/test/mocks/XenEvtchnMock.hpp
@@ -39,28 +39,42 @@ public:
 	typedef std::function<void()> NotifyCbk;
 
 	XenEvtchnMock();
+	~XenEvtchnMock();
 
-	static XenEvtchnMock* getLastInstance() { return sLastInstance; }
-	static void setErrorMode(bool errorMode) { mErrorMode = errorMode; }
-	static bool getErrorMode() { return mErrorMode; }
+	static void setErrorMode(bool errorMode)
+	{
+		std::lock_guard<std::mutex> lock(sMutex);
+
+		sErrorMode = errorMode;
+	}
+	static bool getErrorMode()
+	{
+		std::lock_guard<std::mutex> lock(sMutex);
+
+		return sErrorMode;
+	}
+	static evtchn_port_t getLastNotifiedPort()
+	{
+		std::lock_guard<std::mutex> lock(sMutex);
+
+		return sLastNotifiedPort;
+	}
+	static evtchn_port_t getLastBoundPort()
+	{
+		std::lock_guard<std::mutex> lock(sMutex);
+
+		return sLastBoundPort;
+	}
+	static void signalPort(evtchn_port_t port);
+	static void setNotifyCbk(evtchn_port_t port, NotifyCbk cbk);
 
 	int getFd() const { return mPipe.getFd(); }
-	evtchn_port_t getLastNotifiedPort() const { return mLastNotifiedPort; }
-	evtchn_port_t getLastBoundPort() const { return mLastBoundPort; }
 	evtchn_port_t bind(domid_t domId, evtchn_port_t remotePort);
 	void unbind(evtchn_port_t port);
 	void notifyPort(evtchn_port_t port);
-	void signalPort(evtchn_port_t port);
-	void signalLastBoundPort();
 	evtchn_port_t getPendingPort();
-	void setNotifyCbk(NotifyCbk cbk);
 
 private:
-
-	static XenEvtchnMock* sLastInstance;
-	static evtchn_port_t sPort;
-	static bool mErrorMode;
-
 
 	struct BoundPort
 	{
@@ -69,18 +83,21 @@ private:
 		evtchn_port_t localPort;
 	};
 
+	static std::mutex sMutex;
+	static evtchn_port_t sPort;
+	static bool sErrorMode;
+	static std::list<XenEvtchnMock*> sClients;
+	static int sLastNotifiedPort;
+	static int sLastBoundPort;
+
 	Pipe mPipe;
 
-	std::list<BoundPort> mBoundPorts;
 	std::list<evtchn_port_t> mSignaledPorts;
-
-	int mLastNotifiedPort;
-	int mLastBoundPort;
+	std::list<BoundPort> mBoundPorts;
 
 	NotifyCbk mNotifyCbk;
 
-	std::mutex mMutex;
-
+	static XenEvtchnMock* getClientByPort(evtchn_port_t port);
 	std::list<BoundPort>::iterator getBoundPort(evtchn_port_t port);
 };
 

--- a/test/testBackend.cpp
+++ b/test/testBackend.cpp
@@ -99,9 +99,6 @@ TEST_CASE("BackendHandler", "[backendhandler]")
 
 	SECTION("Check adding frontend")
 	{
-		auto ctrlMock = XenCtrlMock::getLastInstance();
-		auto storeMock = XenStoreMock::getLastInstance();
-
 		REQUIRE(waitForFrontend());
 
 		REQUIRE(gNewFrontDomId == gFrontDomId);

--- a/test/testXenEvtchn.cpp
+++ b/test/testXenEvtchn.cpp
@@ -68,8 +68,6 @@ TEST_CASE("XenEvtchn", "[xenevtchn]")
 
 	XenEvtchn eventChannel(3, 24, eventChannelCbk, errorHandling);
 
-	auto mock = XenEvtchnMock::getLastInstance();
-
 	eventChannel.start();
 
 	SECTION("Check notification")
@@ -79,9 +77,9 @@ TEST_CASE("XenEvtchn", "[xenevtchn]")
 
 		eventChannel.notify();
 
-		REQUIRE(eventChannel.getPort() == mock->getLastNotifiedPort());
+		REQUIRE(eventChannel.getPort() == XenEvtchnMock::getLastNotifiedPort());
 
-		mock->signalPort(eventChannel.getPort());
+		XenEvtchnMock::signalPort(eventChannel.getPort());
 
 		waitForCbk();
 
@@ -113,7 +111,7 @@ TEST_CASE("XenEvtchn", "[xenevtchn]")
 
 		XenEvtchnMock::setErrorMode(true);
 
-		mock->signalPort(eventChannel.getPort());
+		XenEvtchnMock::signalPort(eventChannel.getPort());
 
 		waitForCbk();
 

--- a/test/testXenGnttab.cpp
+++ b/test/testXenGnttab.cpp
@@ -33,9 +33,8 @@ TEST_CASE("XenGnttab", "[xengnttab]")
 	{
 		XenGnttabBuffer xenBuffer(3, 14);
 
-		auto mock = XenGnttabMock::getLastInstance();
-
-		REQUIRE(xenBuffer.size() == mock->getMapBufferSize(xenBuffer.get()));
+		REQUIRE(xenBuffer.size() ==
+				XenGnttabMock::getMapBufferSize(xenBuffer.get()));
 	}
 
 	SECTION("Check multiple pages")
@@ -45,9 +44,8 @@ TEST_CASE("XenGnttab", "[xengnttab]")
 
 		XenGnttabBuffer  xenBuffer(3, refs, count);
 
-		auto mock = XenGnttabMock::getLastInstance();
-
-		REQUIRE(xenBuffer.size() == mock->getMapBufferSize(xenBuffer.get()));
+		REQUIRE(xenBuffer.size() ==
+				XenGnttabMock::getMapBufferSize(xenBuffer.get()));
 	}
 
 	SECTION("Check errors")

--- a/test/testXenStat.cpp
+++ b/test/testXenStat.cpp
@@ -31,8 +31,6 @@ TEST_CASE("XenStat", "[xenctrl]")
 
 	XenCtrlMock::setErrorMode(false);
 
-	auto mock = XenCtrlMock::getLastInstance();
-
 	xc_domaininfo_t info = {};
 
 	domid_t domIds[] = { 1, 2, 3, 4, 5, 6, 7, 8 };
@@ -46,7 +44,7 @@ TEST_CASE("XenStat", "[xenctrl]")
 			info.flags = XEN_DOMINF_running;
 		}
 
-		mock->addDomInfo(info);
+		XenCtrlMock::addDomInfo(info);
 	}
 
 	SECTION("Check getters")

--- a/test/testXenStore.cpp
+++ b/test/testXenStore.cpp
@@ -86,13 +86,11 @@ TEST_CASE("XenStore", "[xenstore]")
 
 	xenStore.start();
 
-	auto mock = XenStoreMock::getLastInstance();
-
 	SECTION("Check getting domain path")
 	{
 		string path = "/local/domain/3/";
 
-		mock->setDomainPath(3, path);
+		XenStoreMock::setDomainPath(3, path);
 
 		REQUIRE_THAT(xenStore.getDomainPath(3), Catch::Matchers::Equals(path));
 	}
@@ -191,7 +189,7 @@ TEST_CASE("XenStore", "[xenstore]")
 
 		xenStore.setWatch(path, watchCbk1);
 
-		mock->writeValue(path, "Changed");
+		XenStoreMock::writeValue(path, "Changed");
 
 		waitForWatch();
 
@@ -204,7 +202,7 @@ TEST_CASE("XenStore", "[xenstore]")
 
 		xenStore.setWatch(path, watchCbk2);
 
-		mock->writeValue(path, value);
+		XenStoreMock::writeValue(path, value);
 
 		waitForWatch();
 


### PR DESCRIPTION
It allows to compile and run backend in front of
mock lib without Xen.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>