### PR TITLE
Set backend to unknown state after initialization

### DIFF
--- a/src/FrontendHandlerBase.cpp
+++ b/src/FrontendHandlerBase.cpp
@@ -266,6 +266,8 @@ void FrontendHandlerBase::init()
 			setBackendState(XenbusStateInitialising);
 		}
 	}
+
+	mBackendState = XenbusStateUnknown;
 }
 
 void FrontendHandlerBase::release()


### PR DESCRIPTION
In order to trigger backend state machine its state should be unknown.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>