### PR TITLE
Make Xen Store accessible for child classes

### DIFF
--- a/include/xen/be/BackendBase.hpp
+++ b/include/xen/be/BackendBase.hpp
@@ -125,6 +125,8 @@ public:
 
 protected:
 
+	XenStore mXenStore;
+
 	/**
 	 * Is called when new frontend detected.
 	 * Basically the client should create
@@ -146,7 +148,6 @@ private:
 	domid_t mDomId;
 	std::string mDeviceName;
 	std::string mFrontendsPath;
-	XenStore mXenStore;
 	std::list<domid_t> mDomainList;
 	std::list<FrontendHandlerPtr> mFrontendHandlers;
 

--- a/src/BackendBase.cpp
+++ b/src/BackendBase.cpp
@@ -76,9 +76,9 @@ namespace XenBackend {
  ******************************************************************************/
 
 BackendBase::BackendBase(const string& name, const string& deviceName) :
+	mXenStore(bind(&BackendBase::onError, this, _1)),
 	mDomId(0),
 	mDeviceName(deviceName),
-	mXenStore(bind(&BackendBase::onError, this, _1)),
 	mLog(name.empty() ? "Backend" : name)
 {
 	mDomId = mXenStore.readInt("domid");


### PR DESCRIPTION
Some of the backends need to access Xen Store which is now
only available for the base class. Make it protected, so
child classes can also use the store.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>