### PR TITLE
Make DMA buffers optional

### DIFF
--- a/src/XenGnttab.cpp
+++ b/src/XenGnttab.cpp
@@ -104,6 +104,8 @@ void XenGnttabBuffer::release()
 	}
 }
 
+#ifdef GNTDEV_DMA_FLAG_WC
+
 /*******************************************************************************
  * XenGnttabDmaBufferExporter
  ******************************************************************************/
@@ -257,5 +259,7 @@ void XenGnttabDmaBufferImporter::release()
 		mDmaBufFd = -1;
 	}
 }
+
+#endif	// GNTDEV_DMA_FLAG_WC
 
 }


### PR DESCRIPTION
commit 0de95c9ca3a9bd ("Add support for gntdev provided dma-buf's")
breaks build on older XEN releases, where DMA buffers are not
supported.

Signed-off-by: Volodymyr Babchuk <vlad.babchuk@gmail.com>