### PR TITLE
Make XenGnttab instance as singleton

### DIFF
--- a/include/xen/be/XenGnttab.hpp
+++ b/include/xen/be/XenGnttab.hpp
@@ -51,6 +51,13 @@ class XenGnttabException : public Exception
  ******************************************************************************/
 class XenGnttab
 {
+public:
+	/**
+	 * Returns the grant table handle
+	 * @return handle
+	 */
+	static xengnttab_handle* getHandle();
+
 private:
 
 	friend class XenGnttabBuffer;
@@ -61,12 +68,6 @@ private:
 	XenGnttab(const XenGnttab&) = delete;
 	XenGnttab& operator=(XenGnttab const&) = delete;
 	~XenGnttab();
-
-	/**
-	 * Returns the grant table handle
-	 * @return handle
-	 */
-	xengnttab_handle* getHandle() const { return mHandle; }
 
 	xengnttab_handle* mHandle;
 };

--- a/src/XenGnttab.cpp
+++ b/src/XenGnttab.cpp
@@ -44,6 +44,13 @@ XenGnttab::~XenGnttab()
 	}
 }
 
+xengnttab_handle* XenGnttab::getHandle()
+{
+	static XenGnttab gnttab;
+
+	return gnttab.mHandle;
+}
+
 /*******************************************************************************
  * XenGnttabBuffer
  ******************************************************************************/
@@ -73,9 +80,7 @@ XenGnttabBuffer::~XenGnttabBuffer()
 void XenGnttabBuffer::init(domid_t domId, const grant_ref_t* refs,
 						   size_t count, int prot)
 {
-	static XenGnttab gnttab;
-
-	mHandle = gnttab.getHandle();
+	mHandle = XenGnttab::getHandle();
 	mBuffer = nullptr;
 	mCount = count;
 
@@ -136,11 +141,10 @@ XenGnttabDmaBufferExporter::~XenGnttabDmaBufferExporter()
 
 void XenGnttabDmaBufferExporter::init(domid_t domId, const GrantRefs &refs)
 {
-	static XenGnttab gnttab;
 	uint32_t fd;
 	int ret;
 
-	mHandle = gnttab.getHandle();
+	mHandle = XenGnttab::getHandle();
 
 	DLOG(mLog, DEBUG) << "Produce DMA buffer from grant references, dom: "
 					  << domId << ", count: " << refs.size();
@@ -219,10 +223,9 @@ XenGnttabDmaBufferImporter::~XenGnttabDmaBufferImporter()
 
 void XenGnttabDmaBufferImporter::init(domid_t domId, int fd, GrantRefs &refs)
 {
-	static XenGnttab gnttab;
 	int ret;
 
-	mHandle = gnttab.getHandle();
+	mHandle = XenGnttab::getHandle();
 
 	DLOG(mLog, DEBUG) << "Produce grant references from DMA buffer, dom: "
 					  << domId << ", fd: " << fd << ", count: " << refs.size();


### PR DESCRIPTION
Different XenGnttab buffers use own XenGnttab object. As xemgnttab device
is resource consuming, use only one XenGnttab object.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>