### PR TITLE
Go into Closed state if frontend is Closed or Closing

### DIFF
--- a/src/FrontendHandlerBase.cpp
+++ b/src/FrontendHandlerBase.cpp
@@ -202,7 +202,7 @@ void FrontendHandlerBase::onStateClosing()
 	if (mBackendState == XenbusStateInitialised ||
 		mBackendState == XenbusStateConnected)
 	{
-		close(XenbusStateInitWait);
+		close(XenbusStateClosed);
 	}
 }
 
@@ -211,7 +211,7 @@ void FrontendHandlerBase::onStateClosed()
 	if (mBackendState == XenbusStateInitialised ||
 		mBackendState == XenbusStateConnected)
 	{
-		close(XenbusStateInitWait);
+		close(XenbusStateClosed);
 	}
 }
 


### PR DESCRIPTION
There are frontends (kbd, for instance) which go into Connected
state if backend is InitWait. This behaviour is not always desired,
e.g. while implementing suspend/hibernate/resume. Make the backend
stay in Closed state and let the frontend or toolstack initiate
connection if any.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>