### PR TITLE
Fix getting BE XS path

### DIFF
--- a/include/xen/be/FrontendHandlerBase.hpp
+++ b/include/xen/be/FrontendHandlerBase.hpp
@@ -122,20 +122,18 @@ public:
 	/**
 	 * @param[in] name                optional frontend name
 	 * @param[in] devName             device name
-	 * @param[in] beDomId             backend domain id
-	 * @param[in] feDomId             frontend domain id
-	 * @param[in] beDevId             backend device id
-	 * @param[in] feDevId             frontend device id
+	 * @param[in] domId               frontend domain id
+	 * @param[in] devId               device id
 	 */
 	FrontendHandlerBase(const std::string& name, const std::string& devName,
-						domid_t beDomId, domid_t feDomId, uint16_t devId = 0);
+						domid_t domId, uint16_t devId = 0);
 
 	virtual ~FrontendHandlerBase();
 
 	/**
 	 * Returns frontend domain id
 	 */
-	domid_t getDomId() const { return mFeDomId; }
+	domid_t getDomId() const { return mDomId; }
 
 	/**
 	 * Returns frontend device id
@@ -250,8 +248,7 @@ private:
 
 	typedef void(FrontendHandlerBase::*StateFn)();
 
-	domid_t mBeDomId;
-	domid_t mFeDomId;
+	domid_t mDomId;
 	uint16_t mDevId;
 	std::string mDevName;
 	std::string mBeStatePath;

--- a/src/FrontendHandlerBase.cpp
+++ b/src/FrontendHandlerBase.cpp
@@ -258,8 +258,6 @@ void FrontendHandlerBase::init()
 			setBackendState(XenbusStateInitialising);
 		}
 	}
-
-	mBackendState = XenbusStateUnknown;
 }
 
 void FrontendHandlerBase::release()

--- a/src/FrontendHandlerBase.cpp
+++ b/src/FrontendHandlerBase.cpp
@@ -51,12 +51,10 @@ namespace XenBackend {
  * FrontendHandlerBase
  ******************************************************************************/
 
-FrontendHandlerBase::FrontendHandlerBase(const string& name,
-										 const string& devName,
-										 domid_t beDomId, domid_t feDomId,
-										 uint16_t devId) :
-	mBeDomId(beDomId),
-	mFeDomId(feDomId),
+FrontendHandlerBase::FrontendHandlerBase(const std::string& name,
+										 const std::string& devName,
+										 domid_t domId, uint16_t devId) :
+	mDomId(domId),
 	mDevId(devId),
 	mDevName(devName),
 	mBackendState(XenbusStateUnknown),
@@ -64,7 +62,7 @@ FrontendHandlerBase::FrontendHandlerBase(const string& name,
 	mXenStore(bind(&FrontendHandlerBase::onError, this, _1)),
 	mLog(name.empty() ? "FrontendHandler" : name)
 {
-	LOG(mLog, DEBUG) << Utils::logDomId(mFeDomId, mDevId)
+	LOG(mLog, DEBUG) << Utils::logDomId(mDomId, mDevId)
 					 << "Create frontend handler";
 
 	init();
@@ -74,7 +72,7 @@ FrontendHandlerBase::~FrontendHandlerBase()
 {
 	stop();
 
-	LOG(mLog, DEBUG) << Utils::logDomId(mFeDomId, mDevId)
+	LOG(mLog, DEBUG) << Utils::logDomId(mDomId, mDevId)
 					 << "Delete frontend handler";
 }
 
@@ -114,7 +112,7 @@ void FrontendHandlerBase::stop()
 
 void FrontendHandlerBase::addRingBuffer(RingBufferPtr ringBuffer)
 {
-	LOG(mLog, INFO) << Utils::logDomId(mFeDomId, mDevId)
+	LOG(mLog, INFO) << Utils::logDomId(mDomId, mDevId)
 					<< "Add ring buffer, ref: "
 					<< ringBuffer->getRef() << ", port: "
 					<< ringBuffer->getPort();
@@ -132,7 +130,7 @@ void FrontendHandlerBase::setBackendState(xenbus_state state)
 		return;
 	}
 
-	LOG(mLog, INFO) << Utils::logDomId(mFeDomId, mDevId)
+	LOG(mLog, INFO) << Utils::logDomId(mDomId, mDevId)
 					<< "Set backend state to: "
 					<< Utils::logState(state);
 
@@ -157,7 +155,7 @@ void FrontendHandlerBase::onStateInitializing()
 {
 	if (mBackendState == XenbusStateConnected)
 	{
-		LOG(mLog, WARNING) << Utils::logDomId(mFeDomId, mDevId)
+		LOG(mLog, WARNING) << Utils::logDomId(mDomId, mDevId)
 						   << "Frontend restarted";
 
 		close(XenbusStateInitWait);
@@ -231,15 +229,9 @@ void FrontendHandlerBase::onStateReconfigured()
 
 void FrontendHandlerBase::initXenStorePathes()
 {
-	stringstream ss;
-
-	ss << mXenStore.getDomainPath(mBeDomId) << "/backend/"
-	   << mDevName << "/"
-	   << mFeDomId << "/" << mDevId;
-
-	mXsBackendPath = ss.str();
-
-	mXsFrontendPath = mXenStore.readString(mXsBackendPath + "/frontend");
+	mXsFrontendPath = mXenStore.getDomainPath(mDomId) + "/device/" + mDevName + 
+					  "/" + to_string(mDevId);
+	mXsBackendPath = mXenStore.readString(mXsFrontendPath + "/backend");
 
 	mFeStatePath = mXsFrontendPath + "/state";
 	mBeStatePath = mXsBackendPath + "/state";
@@ -300,7 +292,7 @@ void FrontendHandlerBase::frontendStateChanged()
 
 	mFrontendState = state;
 
-	LOG(mLog, INFO) << Utils::logDomId(mFeDomId, mDevId)
+	LOG(mLog, INFO) << Utils::logDomId(mDomId, mDevId)
 					<< "Frontend state changed to: "
 					<< Utils::logState(state);
 
@@ -325,7 +317,7 @@ void FrontendHandlerBase::backendStateChanged()
 
 	mBackendState = state;
 
-	LOG(mLog, INFO) << Utils::logDomId(mFeDomId, mDevId)
+	LOG(mLog, INFO) << Utils::logDomId(mDomId, mDevId)
 					<< "Backend state changed to: "
 					<< Utils::logState(state);
 
@@ -352,7 +344,7 @@ void FrontendHandlerBase::onFrontendStateChanged(xenbus_state state)
 	}
 	else
 	{
-		LOG(mLog, WARNING) << Utils::logDomId(mFeDomId, mDevId)
+		LOG(mLog, WARNING) << Utils::logDomId(mDomId, mDevId)
 						   << "Invalid state: " << state;
 	}
 }
@@ -371,7 +363,7 @@ void FrontendHandlerBase::onBackendStateChanged(xenbus_state state)
 
 void FrontendHandlerBase::onError(const std::exception& e)
 {
-	LOG(mLog, ERROR) << Utils::logDomId(mFeDomId, mDevId) << e.what();
+	LOG(mLog, ERROR) << Utils::logDomId(mDomId, mDevId) << e.what();
 
 	mAsyncContext.call(bind(&FrontendHandlerBase::close, this,
 					   XenbusStateClosed));

--- a/tests/testFrontendHandler.cpp
+++ b/tests/testFrontendHandler.cpp
@@ -82,6 +82,8 @@ void TestFrontendHandler::prepareXenStore(const string& devName,
 
 	storeMock.writeValue(bePath + "/frontend", fePath);
 
+	storeMock.writeValue(fePath + "/backend", bePath);
+
 	storeMock.writeValue(fePath + "/state", to_string(XenbusStateUnknown));
 
 	storeMock.writeValue(bePath + "/state", to_string(XenbusStateClosed));

--- a/tests/testFrontendHandler.hpp
+++ b/tests/testFrontendHandler.hpp
@@ -30,7 +30,7 @@ public:
 	TestFrontendHandler(const std::string& devName,
 						domid_t beDomId, domid_t feDomId, uint16_t devId) :
 		XenBackend::FrontendHandlerBase("TestFrontend", devName,
-										beDomId, feDomId, devId)
+										feDomId, devId)
 	{}
 
 	~TestFrontendHandler();


### PR DESCRIPTION
Currently we create BE XS path with dom ID, device name and device ID. But device name could be different from FE and BE side. That's why we have to read proper BE path from FE XS entry instead of creating it manually.

This pull request should be merged once we switched to Xen where VINPUT backend is introduced for VKBD device.

Also VKB device in domain cfg should have backend-type=pv instead of linux.