### PR TITLE
XenGnttabBuffer: handle data offset for dmabufs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,24 @@ message(STATUS "XEN_LIB_PATH                  = ${XEN_LIB_PATH}")
 message(STATUS)
 
 ################################################################################
+# Autodetected options
+################################################################################
+
+include(CheckSymbolExists)
+
+# Test if version 2 of the xengnttab_dmabuf_imp_to_refs and
+# xengnttab_dmabuf_exp_from_refs functions are supported:
+# these functions have an additional data_ofs parameter
+# to set/get the offset of the data in the dma-buf's scatter-gather
+# table
+set(CMAKE_REQUIRED_LIBRARIES xengnttab)
+check_symbol_exists("xengnttab_dmabuf_imp_to_refs_v2" "xengnttab.h" GNTTAB_HAS_DMABUF_OFFSET)
+
+if(GNTTAB_HAS_DMABUF_OFFSET)
+	add_definitions(-DGNTTAB_HAS_DMABUF_OFFSET)
+endif()
+
+################################################################################
 # Compiler flags
 ################################################################################
 

--- a/include/xen/be/XenGnttab.hpp
+++ b/include/xen/be/XenGnttab.hpp
@@ -92,21 +92,25 @@ class XenGnttabBuffer
 public:
 
 	/**
-	 * @param[in] domId domain id
-	 * @param[in] ref   grant reference id
-	 * @param[in] prot  same flag as in mmap()
+	 * @param[in] domId  domain id
+	 * @param[in] ref    grant reference id
+	 * @param[in] prot   same flag as in mmap()
+	 * @param[in] offset offset of the data inside the buffer
 	 */
 	XenGnttabBuffer(domid_t domId, grant_ref_t ref,
-					int prot = PROT_READ | PROT_WRITE);
+					int prot = PROT_READ | PROT_WRITE,
+					size_t offset = 0);
 
 	/**
-	 * @param[in] domId domain id
-	 * @param[in] refs  array of grant reference ids
-	 * @param[in] count number of grant refgerence ids
-	 * @param[in] prot  same flag as in mmap()
+	 * @param[in] domId  domain id
+	 * @param[in] refs   array of grant reference ids
+	 * @param[in] count  number of grant refgerence ids
+	 * @param[in] prot   same flag as in mmap()
+	 * @param[in] offset offset of the data inside the buffer
 	 */
 	XenGnttabBuffer(domid_t domId, const grant_ref_t* refs, size_t count,
-					int prot = PROT_READ | PROT_WRITE);
+					int prot = PROT_READ | PROT_WRITE,
+					size_t offset = 0);
 	XenGnttabBuffer(const XenGnttabBuffer&) = delete;
 	XenGnttabBuffer& operator=(XenGnttabBuffer const&) = delete;
 	~XenGnttabBuffer();
@@ -114,7 +118,7 @@ public:
 	/**
 	 * Returns pointer to the mapped buffer.
 	 */
-	void* get() const { return mBuffer; }
+	void* get() const { return static_cast<uint8_t*>(mBuffer) + mOffset; }
 
 	/**
 	 * Returns sizeo of the mapped buffer.
@@ -123,12 +127,14 @@ public:
 
 private:
 	void* mBuffer;
+	size_t mOffset;
 	xengnttab_handle* mHandle;
 	size_t mCount;
 	Log mLog;
 
 
-	void init(domid_t domId, const grant_ref_t* refs, size_t count, int prot);
+	void init(domid_t domId, const grant_ref_t* refs, size_t count, int prot,
+			  size_t offset);
 	void release();
 };
 

--- a/include/xen/be/XenGnttab.hpp
+++ b/include/xen/be/XenGnttab.hpp
@@ -161,7 +161,8 @@ public:
 	 *            will be produced
 	 * @param[in] refs  vector of grant reference ids
 	 */
-	XenGnttabDmaBufferExporter(domid_t domId, const GrantRefs &refs);
+	XenGnttabDmaBufferExporter(domid_t domId, const GrantRefs &refs,
+							   size_t offset = 0);
 
 	int getFd() const { return mDmaBufFd; }
 
@@ -178,7 +179,7 @@ private:
 	xengnttab_handle* mHandle;
 	Log mLog;
 
-	void init(domid_t domId, const GrantRefs &refs);
+	void init(domid_t domId, const GrantRefs &refs, size_t offset);
 	void release();
 };
 
@@ -213,10 +214,16 @@ public:
 			delete;
 	~XenGnttabDmaBufferImporter();
 
+	/**
+	 * Returns offset of the data of the buffer.
+	 */
+	size_t offset() const { return mOffset; }
+
 private:
 	GrantRefs mRefs;
 	int mDmaBufFd;
 	xengnttab_handle* mHandle;
+	size_t mOffset;
 	Log mLog;
 
 	void init(domid_t domId, int fd, GrantRefs &refs);

--- a/src/XenGnttab.cpp
+++ b/src/XenGnttab.cpp
@@ -55,17 +55,18 @@ xengnttab_handle* XenGnttab::getHandle()
  * XenGnttabBuffer
  ******************************************************************************/
 
-XenGnttabBuffer::XenGnttabBuffer(domid_t domId, grant_ref_t ref, int prot) :
-		XenGnttabBuffer(domId, &ref, 1, prot)
+XenGnttabBuffer::XenGnttabBuffer(domid_t domId, grant_ref_t ref, int prot,
+								 size_t offset) :
+		XenGnttabBuffer(domId, &ref, 1, prot, offset)
 {
 
 }
 
 XenGnttabBuffer::XenGnttabBuffer(domid_t domId, const grant_ref_t* refs,
-								 size_t count, int prot) :
+								 size_t count, int prot, size_t offset) :
 	mLog("XenGnttabBuffer")
 {
-	init(domId, refs, count, prot);
+	init(domId, refs, count, prot, offset);
 }
 
 XenGnttabBuffer::~XenGnttabBuffer()
@@ -78,14 +79,16 @@ XenGnttabBuffer::~XenGnttabBuffer()
  ******************************************************************************/
 
 void XenGnttabBuffer::init(domid_t domId, const grant_ref_t* refs,
-						   size_t count, int prot)
+						   size_t count, int prot, size_t offset)
 {
 	mHandle = XenGnttab::getHandle();
 	mBuffer = nullptr;
+	mOffset = offset;
 	mCount = count;
 
 	DLOG(mLog, DEBUG) << "Create grant table buffer, dom: " << domId
-					  << ", count: " << count << ", ref: " << *refs;
+					  << ", count: " << count << ", ref: " << *refs
+					  << ", buffer offset: " << offset;
 
 
 	mBuffer = xengnttab_map_domain_grant_refs(mHandle, count, domId,


### PR DESCRIPTION
Handle additional data offset parameter while exporting and
importing dmabufs: dmabuf is backed by a scatter-gather table
and has offset parameter which tells where the actual data starts:
  - when dmabuf is created (exported) from grant references then
    data_ofs is used to set the offset field in the scatter list
    of the new dma-buf
  - when dma-buf is imported and then grant references provided
    to the user space then data_ofs is used to report that offset
    to user-space

Note! There is a dependency on libgnttab if it supports importing/
exporting dmabufs with data offset, so conditional compilation is
employed: new definition GNTTAB_HAS_DMABUF_OFFSET is set if the
library supports the offset. If it doesn't and a non-zero offset is
requested/provided, then a run-time exception is raised.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>