### PR TITLE
Add <cstdint> to Pipe.cpp

### DIFF
--- a/tests/mocks/Pipe.cpp
+++ b/tests/mocks/Pipe.cpp
@@ -22,7 +22,7 @@
 
 #include <cstring>
 #include <string>
-
+#include <cstdint>
 #include <unistd.h>
 
 #include "Exception.hpp"


### PR DESCRIPTION
The yocto scarthgap uses GCC 13, and according to the manual 'Porting to GCC 13', some headers need to be included explicitly. Without the explicit inclusion of the `cstdint` we will have a build error 'uint8_t is not defined' on the scarthgap.